### PR TITLE
Replace set-output using

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -32,7 +32,7 @@ runs:
       - name: Find yarn cache
         shell: bash
         id: yarn-cache-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Restore cache
         uses: actions/cache@v2

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -24,10 +24,10 @@ jobs:
           ios_update_uri=$(echo "$update_output" | jq -r '.[] | select(.platform == "ios") | .manifestPermalink ')
           android_update_id=$(echo "$update_output" | jq -r '.[] | select(.platform == "android") | .id ')
           android_update_uri=$(echo "$update_output" | jq -r '.[] | select(.platform == "android") | .manifestPermalink ')
-          echo "::set-output name=ios_update_id::$ios_update_id"
-          echo "::set-output name=ios_update_uri::$ios_update_uri"
-          echo "::set-output name=android_update_id::$android_update_id"
-          echo "::set-output name=android_update_uri::$android_update_uri"
+          echo "ios_update_id=$ios_update_id" >> $GITHUB_OUTPUT
+          echo "ios_update_uri=$ios_update_uri" >> $GITHUB_OUTPUT
+          echo "android_update_id=$android_update_id" >> $GITHUB_OUTPUT
+          echo "android_update_uri=$android_update_uri" >> $GITHUB_OUTPUT
 
       - name: Comment PR
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/